### PR TITLE
kexec uefi ramdisk support

### DIFF
--- a/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
+++ b/MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDriver.c
@@ -155,6 +155,12 @@ RamDiskDxeEntryPoint (
   }
 
   //
+  // Initialize the list of registered RAM disks maintained by the driver
+  // before installing the protocol
+  //
+  InitializeListHead (&RegisteredRamDisks);
+
+  //
   // Install the EFI_RAM_DISK_PROTOCOL and RAM disk private data onto a
   // new handle
   //
@@ -169,11 +175,6 @@ RamDiskDxeEntryPoint (
   if (EFI_ERROR (Status)) {
     goto ErrorExit;
   }
-
-  //
-  // Initialize the list of registered RAM disks maintained by the driver
-  //
-  InitializeListHead (&RegisteredRamDisks);
 
   Status = EfiCreateEventReadyToBootEx (
              TPL_CALLBACK,

--- a/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.c
+++ b/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.c
@@ -8,6 +8,11 @@
 **/
 #include "BlSupportDxe.h"
 
+#include <Protocol/DevicePath.h>
+#include <Library/DevicePathLib.h>
+#include <Protocol/RamDisk.h>
+#include <Library/MemoryAllocationLib.h>
+
 /**
   Reserve MMIO/IO resource in GCD
 
@@ -77,6 +82,54 @@ ReserveResourceInGcd (
     ASSERT_EFI_ERROR (Status);
   }
   return Status;
+}
+
+
+static void EFIAPI ramdisk_callback(EFI_EVENT event, void * context)
+{
+  const SYSTEM_TABLE_INFO *SystemTableInfo = context;
+  const unsigned char * ramdisk_base = (const void*) SystemTableInfo->RamDiskBase;
+  const UINTN ramdisk_size = SystemTableInfo->RamDiskSize;
+
+  if (!ramdisk_base || !ramdisk_size)
+    return;
+
+  EFI_STATUS                 Status;
+  EFI_RAM_DISK_PROTOCOL      *RamDisk;
+  EFI_DEVICE_PATH_PROTOCOL   *DevicePath;
+  EFI_GUID                   *RamDiskType = &gEfiVirtualDiskGuid;
+
+  Status = gBS->LocateProtocol(&gEfiRamDiskProtocolGuid, NULL, (VOID**) &RamDisk);
+  // if there is no protocol, we've been signalled too early. we'll try again later
+  if (EFI_ERROR (Status))
+    return;
+
+  // it is necessary to copy the ramdisk from the kexec allocated memory to uefi allocated
+  // memory. otherwise the memory will be reclaimed during the boot process, leading to
+  // a corrupt BCD hive or other propblems.
+  const unsigned char * ramdisk_copy = AllocateCopyPool(ramdisk_size, (const void*) ramdisk_base);
+  if (!ramdisk_copy)
+  {
+    DEBUG((EFI_D_ERROR, "allocate %d bytes for ramdisk copy failed\n", ramdisk_size));
+    return;
+  }
+
+  Status = RamDisk->Register(
+       (UINTN) ramdisk_copy,
+       ramdisk_size,
+       RamDiskType,
+       NULL,
+       &DevicePath
+  );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "ramdisk_setup: Failed to register RAM Disk - %r\n", Status));
+    return;
+  }
+
+  VOID * Temp = ConvertDevicePathToText(DevicePath, TRUE, TRUE);
+  DEBUG ((EFI_D_INFO, "ramdisk_setup: ram disk %p + %x: device path %S\n", ramdisk_copy, ramdisk_size, Temp));
+  FreePool(Temp);
 }
 
 
@@ -179,6 +232,17 @@ BlDxeEntryPoint (
     Status = PcdSet64S (PcdPciExpressBaseSize, AcpiBoardInfo->PcieBaseSize);
     ASSERT_EFI_ERROR (Status);
   }
+
+  // Wait for the RamDiskProtocol to become available
+  static EFI_EVENT ramdisk_event;
+  static void * ramdisk_registration;
+
+  Status = gBS->CreateEvent(EVT_NOTIFY_SIGNAL, TPL_CALLBACK, ramdisk_callback, SystemTableInfo, &ramdisk_event);
+  ASSERT_EFI_ERROR(Status);
+  Status = gBS->RegisterProtocolNotify(&gEfiRamDiskProtocolGuid, ramdisk_event, &ramdisk_registration);
+  ASSERT_EFI_ERROR(Status);
+  Status = gBS->SignalEvent(ramdisk_event);
+  ASSERT_EFI_ERROR(Status);
 
   return EFI_SUCCESS;
 }

--- a/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
+++ b/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
@@ -40,6 +40,7 @@
   BaseMemoryLib
   UefiLib
   HobLib
+  DevicePathLib
 
 [Guids]
   gEfiAcpiTableGuid
@@ -48,6 +49,10 @@
   gUefiSystemTableInfoGuid
   gUefiAcpiBoardInfoGuid
   gEfiGraphicsInfoHobGuid
+  gEfiVirtualDiskGuid ## CONSUMES
+
+[Protocols]
+  gEfiRamDiskProtocolGuid ## SOMETIMES_CONSUMES
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution

--- a/UefiPayloadPkg/Include/Guid/SystemTableInfoGuid.h
+++ b/UefiPayloadPkg/Include/Guid/SystemTableInfoGuid.h
@@ -21,6 +21,8 @@ typedef struct {
   UINT32    AcpiTableSize;
   UINT64    SmbiosTableBase;
   UINT32    SmbiosTableSize;
+  UINT64    RamDiskBase;
+  UINT32    RamDiskSize;
 } SYSTEM_TABLE_INFO;
 
 #endif

--- a/UefiPayloadPkg/Library/LbParseLib/LbParseLib.c
+++ b/UefiPayloadPkg/Library/LbParseLib/LbParseLib.c
@@ -55,9 +55,7 @@ const UefiPayloadConfig* GetUefiPayLoadConfig() {
 
   DEBUG((DEBUG_ERROR, "Expect payload config version %016lx or %016lx, but get %016lx\n",
          UEFI_PAYLOAD_CONFIG_VERSION1, UEFI_PAYLOAD_CONFIG_VERSION2, config->Version));
-  CpuDeadLoop ();
-  while(1)
-    ;
+  return NULL;
 }
 
 // Align the address and add memory rang to MemInfoCallback
@@ -189,7 +187,8 @@ ParseMemoryInfo(IN BL_MEM_INFO_CALLBACK MemInfoCallback, IN VOID* Params) {
     // look for the mem=start,end,type 
     while((cmdline = cmdline_next(cmdline, &option)))
     {
-      if (strncmp(option, "mem=", 4) != 0)
+      if (strncmp(option, "mem=", 4) != 0
+      &&  strncmp(option, "ramdisk=", 8) != 0)
         continue;
 
       if (cmdline_ints(option, args, 3) != 3)
@@ -243,7 +242,7 @@ ParseSystemTable(OUT SYSTEM_TABLE_INFO* SystemTableInfo) {
   {
     const char * cmdline = config->config.v2.cmdline;
     const char * option;
-    uint64_t args[2];
+    uint64_t args[3];
 
     // look for the acpi config
     while((cmdline = cmdline_next(cmdline, &option)))
@@ -276,6 +275,21 @@ ParseSystemTable(OUT SYSTEM_TABLE_INFO* SystemTableInfo) {
           SystemTableInfo->SmbiosTableBase = args[0];
         if (count > 1)
           SystemTableInfo->SmbiosTableSize = args[1];
+      }
+
+      if (strncmp(option, "ramdisk=", 8) == 0)
+      {
+        const int count = cmdline_ints(option, args, 3);
+        if (count < 0)
+        {
+          DEBUG((DEBUG_ERROR, "Parse error: '%a'\n", option));
+          continue;
+        }
+
+        if (count > 0)
+          SystemTableInfo->RamDiskBase = args[0];
+        if (count > 1)
+          SystemTableInfo->RamDiskSize = args[1];
       }
     }
   }

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -357,6 +357,13 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase|0
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|3
 
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfHostBridgePciDevId|0x29c0
+  gUefiOvmfPkgTokenSpaceGuid.PcdPciIoBase|0x0
+  gUefiOvmfPkgTokenSpaceGuid.PcdPciIoSize|0x0
+  gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio32Base|0x0
+  gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio32Size|0x0
+  gUefiOvmfPkgTokenSpaceGuid.PcdPciMmio64Base|0x0
+
   ## This PCD defines the video horizontal resolution.
   #  This PCD could be set to 0 then video resolution could be at highest resolution.
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution|0
@@ -470,6 +477,7 @@
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
   MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
   MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
+  MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
   FatPkg/EnhancedFatDxe/Fat.inf
   MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
   MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
@@ -521,6 +529,9 @@
   MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
 !endif
   UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
+
+  OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+
 
   #------------------------------
   #  Build the shell

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -138,7 +138,7 @@ INF MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
 !endif
 
 #
-# Console Support
+# Console Support (including Qemu graphics)
 #
 INF MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
 INF MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf
@@ -147,6 +147,8 @@ INF MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
 INF MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
 !endif
 INF UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
+INF OvmfPkg/QemuVideoDxe/QemuVideoDxe.inf
+
 
 #
 # SCSI/ATA/IDE/DISK Support
@@ -154,6 +156,7 @@ INF UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
 INF MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
 INF MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
 INF MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
+INF MdeModulePkg/Universal/Disk/RamDiskDxe/RamDiskDxe.inf
 INF MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
 INF MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
 INF MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf


### PR DESCRIPTION
This patch adds support for creating a UEFI ramdisk by passing in the command line parameter ramdisk=base,len,type, where type is the UEFI memory type to be reserved (typically 5 for reserved memory). If the ramdisk is a GPT formatted partition image that contains an EFI System Partition, the BDS will boot from it without requiring an ESP on the local harddisk.

It also includes a fix for a bug in the RamDiskDxe that causes a crash if a ram disk is registered immediately after the protocol is registered due to an uninitialized linked list: https://bugzilla.tianocore.org/show_bug.cgi?id=3483